### PR TITLE
Import orphan Storable (Complex a) instance from base-orphans

### DIFF
--- a/Numeric/Jalla/Types.hs
+++ b/Numeric/Jalla/Types.hs
@@ -34,6 +34,7 @@ module Numeric.Jalla.Types (
 ) where
 
 import Data.Complex
+import Data.Orphans ()
 import Foreign.C.Types
 import Foreign.Marshal.Array
 import Foreign
@@ -89,22 +90,6 @@ class LAPACKEEnum e le where
 
 f :: Complex a -> a
 f _ = undefined
-
-instance (RealFloat a, Storable a) => Storable (Complex a) where
-  -- sizeOf c = s where s = 2 * (sizeOf (f c))
-  sizeOf = (2 *) . sizeOf . f
-  alignment = alignment . f
-
-  peek p = peek p1 >>= \r -> peek p2 >>= \i -> return $ r :+ i
-    where
-      p1 = castPtr p
-      p2 = advancePtr p1 1
-
-  poke p c = poke p' r >> poke (advancePtr p' 1) i
-    where p' = castPtr p
-          r = realPart c
-          i = imagPart c
-
 
 {-| Defines a scalar type for each field type. Those are 'Complex' 'CFloat'
     and 'CFloat', as well as 'Complex' 'CDouble' and 'CDouble'. -}

--- a/jalla.cabal
+++ b/jalla.cabal
@@ -56,7 +56,7 @@ Library
                    Numeric.Jalla.Types
                    Numeric.Jalla.Test
 
-  build-depends: base > 4.0.0 && < 4.7.1, mtl -any,
+  build-depends: base > 4.0.0 && < 4.7.1, base-orphans (>= 0.3.2), mtl -any,
                  convertible -any,  random (>=1.0.1), QuickCheck (>= 2.4.2)
 
   buildable: True


### PR DESCRIPTION
This pull request consolidates `jalla`'s orphan `Storable (Complex a)` instance with the [one defined in `base-orphans`](https://github.com/haskell-compat/base-orphans/blob/0a62d9e77e9fd242540b1e6e104ead9128e93ad1/src/Data/Orphans.hs#L1184-1195). This will prevent instance conflicts if anyone uses `jalla` with [other libraries](http://packdeps.haskellers.com/reverse/base-orphans) that transitively depend on `base-orphans`.
